### PR TITLE
Bnd Maven Plugins consistent naming

### DIFF
--- a/_tools/maven-bundle.md
+++ b/_tools/maven-bundle.md
@@ -1,7 +1,7 @@
 ---
 title: Bnd Maven Plugins
 layout: default
-summary: Bnd Maven Plugins
+summary: The Bnd Maven Plugins.
 ---
 
 See the [documentation on GitHub][1] for details on how to configure and

--- a/_tools/maven-bundle.md
+++ b/_tools/maven-bundle.md
@@ -1,10 +1,10 @@
 ---
-title: Maven Plugins
+title: Bnd Maven Plugins
 layout: default
-summary: The Maven Plugins for Bnd.
+summary: Bnd Maven Plugins
 ---
 
 See the [documentation on GitHub][1] for details on how to configure and
-use the Maven plugins for Bnd.
+use the Bnd Maven Plugins.
 
 [1]: https://github.com/bndtools/bnd/blob/master/maven/README.md


### PR DESCRIPTION
use "Bnd Maven Plugins" everywhere
