### PR TITLE
Added osgi-run to Bnd _tools

### DIFF
--- a/_tools/osgi-run.md
+++ b/_tools/osgi-run.md
@@ -1,0 +1,13 @@
+---
+title: OSGi-Run Plugin
+layout: default
+summary: A Gradle Plugin to create and run an OSGi runtime. 
+---
+
+This Gradle Plugin creates an OSGi runtime based on the project's dependencies,
+which may include the project itself as well as its subprojects, and can run it with
+Apache Felix, Equinox or Knopflerfish.
+
+See the [osgi-run][1] page on GitHub for details.
+
+[1]: https://github.com/renatoathaydes/osgi-run


### PR DESCRIPTION
osgi-run uses Bnd to wrap Gradle dependencies as bundles if necessary before adding  them to the OSGi runtime.
It also uses it indirectly via the Gradle OSGi Plugin, which is included by osgi-run.
